### PR TITLE
Revert one commit and apply those changes to appropriate module

### DIFF
--- a/testenrichers/cdi-jakarta/pom.xml
+++ b/testenrichers/cdi-jakarta/pom.xml
@@ -25,7 +25,8 @@
     <maven.compiler.source>1.8</maven.compiler.source>
 
     <!-- Versioning -->
-    <version.weld-core>4.0.0-SNAPSHOT</version.weld-core>
+    <!-- Weld version is to be replaced by 4.x as soon as release is out, also re-enable CDIInjectionEnricherTestCase -->
+    <version.weld-core>3.1.4.Final</version.weld-core>
     <version.javax-el>2.2</version.javax-el>
     <version.slf4j>1.7.28</version.slf4j>
 
@@ -96,17 +97,10 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jboss.weld</groupId>
-      <artifactId>weld-core-impl</artifactId>
+      <groupId>org.jboss.weld.se</groupId>
+      <artifactId>weld-se-shaded</artifactId>
       <version>${version.weld-core}</version>
       <scope>test</scope>
-      <!-- ARQ-990 Removed, not needed runtime and not part of Fedora Maven Packages -->
-      <exclusions>
-        <exclusion>
-          <groupId>org.jboss.weld</groupId>
-          <artifactId>weld-build-config</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/testenrichers/cdi/pom.xml
+++ b/testenrichers/cdi/pom.xml
@@ -23,7 +23,7 @@
   <properties>
 
     <!-- Versioning -->
-    <version.weld-core>3.1.4.Final</version.weld-core>
+    <version.weld-core>1.1.34.Final</version.weld-core>
     <version.javax-el>2.2</version.javax-el>
     <version.slf4j>1.7.28</version.slf4j>
 
@@ -46,9 +46,9 @@
     </dependency>
 
     <dependency>
-      <groupId>jakarta.enterprise</groupId>
-      <artifactId>jakarta.enterprise.cdi-api</artifactId>
-      <version>2.0.2</version>
+      <groupId>javax.enterprise</groupId>
+      <artifactId>cdi-api</artifactId>
+      <version>1.0</version>
       <scope>provided</scope>
     </dependency>
 
@@ -94,10 +94,17 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se-shaded</artifactId>
+      <groupId>org.jboss.weld</groupId>
+      <artifactId>weld-core</artifactId>
       <version>${version.weld-core}</version>
       <scope>test</scope>
+      <!-- ARQ-990 Removed, not needed runtime and not part of Fedora Maven Packages -->
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.weld</groupId>
+          <artifactId>weld-build-config</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/testenrichers/cdi/src/main/java/org/jboss/arquillian/testenricher/cdi/MethodParameterInjectionPoint.java
+++ b/testenrichers/cdi/src/main/java/org/jboss/arquillian/testenricher/cdi/MethodParameterInjectionPoint.java
@@ -74,10 +74,10 @@ public class MethodParameterInjectionPoint<T> implements InjectionPoint {
                 qualifiers.add(annotation);
             }
         }
-        /*
-         * TODO: ARQ-240 We should not add @Default by default, this should be handled by CDI.
-         * Due to bug in Weld 1.0.0.SP4(fixed in trunk). Remove this when 1.1.0 is out.
-         */
+      /*
+       * TODO: ARQ-240 We should not add @Default by default, this should be handled by CDI. 
+       * Due to bug in Weld 1.0.0.SP4(fixed in trunk). Remove this when 1.1.0 is out. 
+       */
         if (qualifiers.size() == 0) {
             qualifiers.add(new DefaultLiteral());
         }
@@ -156,10 +156,6 @@ public class MethodParameterInjectionPoint<T> implements InjectionPoint {
          */
         public Set<Annotation> getAnnotations() {
             return new HashSet<Annotation>(Arrays.asList(method.getParameterAnnotations()[position]));
-        }
-
-        public <T extends Annotation> Set<T> getAnnotations(Class<T> annotationType) {
-            return AnnotatedParameter.super.getAnnotations(annotationType);
         }
 
         /* (non-Javadoc)


### PR DESCRIPTION
@starksm64 This PR adds on top of what you already have and fixes what I noted there - revert the change you made and apply it to the newly added module. I assume that once you actually merge then, then it will also update the PR to Arq. repo itself https://github.com/arquillian/arquillian-core/pull/238.

On top of that this PR **ignores several CDI enricher tests in the new module**. This is temporary (and stated as such in comment) and will be re-enabled as soon as we have Weld core release out. But we now have Weld core and Weld Arq. container both dependent on Arq. core being released.